### PR TITLE
Enable aggregator to handle variable client counts

### DIFF
--- a/openfhe_lib/bfv/openFHE.py
+++ b/openfhe_lib/bfv/openFHE.py
@@ -28,10 +28,10 @@ def decrypt_weights(cipher_file) -> list[float]:
     """
     
     stdout = subprocess.run([f"{cwd}/build/client", cipher_file], capture_output=True).stdout.decode()
-    return [float(int(w) / (4 * WW)) for w in stdout.split("@")]
+    return [float(int(w) / WW) for w in stdout.split("@")]
 
-def aggregator():
+def aggregator(n_hospitals: int):
     """ This function will be used by server to calculate aggregated global model's weights by applying
         homomorphic encryption to encrypted local model's weights of clients
     """
-    subprocess.run([f"{cwd}/build/server"])
+    subprocess.run([f"{cwd}/build/server", str(n_hospitals)])

--- a/openfhe_lib/bfv/server.cpp
+++ b/openfhe_lib/bfv/server.cpp
@@ -88,13 +88,17 @@ void load_client_encrypted_weights() {
     }
 }
 
-void aggregator(std::vector< Ciphertext<DCRTPoly> >encrypted_weights, int64_t n) {
+void aggregator(std::vector< Ciphertext<DCRTPoly> > encrypted_weights, double n) {
     /*
-        This function peform weights aggregation (federated learning concept)
+        This function performs weights aggregation (federated learning concept).
+        The averaged model is computed homomorphically by summing all encrypted
+        weights and multiplying by 1/n.
     */
-    auto result = encrypted_weights[0];
-    for(int i=1; i<encrypted_weights.size(); ++i)
-        result = CC->EvalAdd(result, encrypted_weights[i]);
+    auto sum = encrypted_weights[0];
+    for (size_t i = 1; i < encrypted_weights.size(); ++i)
+        sum = CC->EvalAdd(sum, encrypted_weights[i]);
+
+    auto result = CC->EvalMult(sum, 1.0 / n);
 
     // saving server result
     if (!Serial::SerializeToFile(DATAFOLDER + "/enc_aggregator_weight_server.txt", result, SerType::BINARY)) {
@@ -108,12 +112,16 @@ int main(int argc, char* argv[]) {
     load_crypto_context(CC);
     load_public_key(serverPubKey);
     load_mult_key();
-    
-    // load clients's encrypted weights
+
+    // load clients' encrypted weights
     load_client_encrypted_weights();
-    
+
+    // number of participating hospitals is provided as the first argument
+    double n_hospitals = 4.0;
+    if (argc > 1)
+        n_hospitals = std::stod(argv[1]);
+
     // perform aggregation
-    int64_t n_hospitals = 4;
     aggregator(enc_weights, n_hospitals);
     return 0;
 }

--- a/openfhe_lib/bgv/openFHE.py
+++ b/openfhe_lib/bgv/openFHE.py
@@ -28,10 +28,10 @@ def decrypt_weights(cipher_file) -> list[float]:
     """
     
     stdout = subprocess.run([f"{cwd}/build/client", cipher_file], capture_output=True).stdout.decode()
-    return [float(int(w) / (4 * WW)) for w in stdout.split("@")]
+    return [float(int(w) / WW) for w in stdout.split("@")]
 
-def aggregator():
+def aggregator(n_hospitals: int):
     """ This function will be used by server to calculate aggregated global model's weights by applying
         homomorphic encryption to encrypted local model's weights of clients
     """
-    subprocess.run([f"{cwd}/build/server"])
+    subprocess.run([f"{cwd}/build/server", str(n_hospitals)])

--- a/openfhe_lib/bgv/server.cpp
+++ b/openfhe_lib/bgv/server.cpp
@@ -88,13 +88,17 @@ void load_client_encrypted_weights() {
     }
 }
 
-void aggregator(std::vector< Ciphertext<DCRTPoly> >encrypted_weights, int64_t n) {
+void aggregator(std::vector< Ciphertext<DCRTPoly> > encrypted_weights, double n) {
     /*
-        This function peform weights aggregation (federated learning concept)
+        This function performs weights aggregation (federated learning concept).
+        The averaged model is computed homomorphically by summing all encrypted
+        weights and multiplying by 1/n.
     */
-    auto result = encrypted_weights[0];
-    for(int i=1; i<encrypted_weights.size(); ++i)
-        result = CC->EvalAdd(result, encrypted_weights[i]);
+    auto sum = encrypted_weights[0];
+    for (size_t i = 1; i < encrypted_weights.size(); ++i)
+        sum = CC->EvalAdd(sum, encrypted_weights[i]);
+
+    auto result = CC->EvalMult(sum, 1.0 / n);
 
     // saving server result
     if (!Serial::SerializeToFile(DATAFOLDER + "/enc_aggregator_weight_server.txt", result, SerType::BINARY)) {
@@ -108,12 +112,15 @@ int main(int argc, char* argv[]) {
     load_crypto_context(CC);
     load_public_key(serverPubKey);
     load_mult_key();
-    
-    // load clients's encrypted weights
+
+    // load clients' encrypted weights
     load_client_encrypted_weights();
-    
+
+    double n_hospitals = 4.0;
+    if (argc > 1)
+        n_hospitals = std::stod(argv[1]);
+
     // perform aggregation
-    int64_t n_hospitals = 4;
     aggregator(enc_weights, n_hospitals);
     return 0;
 }


### PR DESCRIPTION
## Summary
- compute mean homomorphically in BFV/BGV servers by dividing using `EvalMult`
- allow passing hospital count to servers
- update Python wrappers for BFV/BGV to remove hard coded divisor and accept hospital count

## Testing
- `pytest -q`
- `python -m py_compile openfhe_lib/bfv/openFHE.py openfhe_lib/bgv/openFHE.py` *(passes)*
- `cmake --build openfhe_lib/bfv/build` *(fails: `openfhe.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eada041548326893a67ac713cf941